### PR TITLE
Adding the --named-keychains arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ protodeep.egg-info/
 *.proto
 *.pdeep
 .venv
+*_pb2.py

--- a/protodeep/cli.py
+++ b/protodeep/cli.py
@@ -16,6 +16,7 @@ def parse_and_run():
     parser.add_argument('-t', '--type', required=True, type=str, help="Either protobuf (raw protobuf content), or protodeep (a ProtoDeep file).")
     parser.add_argument('-d', '--definitions', type=str, help="The file containing the custom protobuf definitions.")
     parser.add_argument('-na', '--no-autodetect', action='store_true', default=False, help="Don't try to autodetect if it's a raw HTTP request.")
+    parser.add_argument('-nk', '--named-keychains', action='store_true', default=False, help="Show and extract only named keychains.")
     parser.add_argument('-s', '--stdin', action='store_true', default=False, help="Parse from stdin.")
     parser.add_argument('-b', '--base64', action='store_true', default=False, help="If this is a base64 input, so it automatically decodes it.")
     parser.add_argument('-hx', '--hex', action='store_true', default=False, help="If this is a hex input, so it automatically decodes it.")
@@ -59,5 +60,6 @@ def process_args(args: argparse.Namespace):
         data_type=args.type,
         compile=args.compile,
         no_print=args.no_print,
-        schema_name=args.name
+        schema_name=args.name,
+        named_keychains=args.named_keychains
     )

--- a/protodeep/internals.py
+++ b/protodeep/internals.py
@@ -51,8 +51,6 @@ def clean_schema(schema, parsed, definitions={}, named_keychains=False) -> tuple
                         if isinstance(sparsed, list):
                             sub["seen_repeated"] = True # Repeated sub
                         sub["message_typedef"] = _clean_schema(sub["message_typedef"], sparsed, new_key_chain, defs, named_keychains)
-                        if skey in sparsed and named_keychains:
-                            del(parsed[key])
                 elif isinstance(parsed, list):
                     for item in parsed:
                         if skey in item:
@@ -61,11 +59,11 @@ def clean_schema(schema, parsed, definitions={}, named_keychains=False) -> tuple
                                 sub["seen_repeated"] = True # Repeated sub
                             sub["message_typedef"] = _clean_schema(sub["message_typedef"], sparsed, new_key_chain, defs, named_keychains)
 
-            if named_keychains and "message_typedef" not in sub and not sub.get("name"):
+            if named_keychains and not sub.get("message_typedef") and not sub.get("name"):
                 del(message[key])
             else:
                 message[key] = sub
         return message
     
-    _clean_schema(schema, parsed, defs=definitions, named_keychains=named_keychains)
+    schema = _clean_schema(schema, parsed, defs=definitions, named_keychains=named_keychains)
     return schema, custom_types_defined

--- a/protodeep/lib.py
+++ b/protodeep/lib.py
@@ -158,7 +158,7 @@ class ProtoDeepSchema():
         cs = Console(highlight=False)
         _pretty_print(self.schema, self.values)
 
-def guess_schema(data: bytes, definitions: dict={}, bruteforce_index=20, no_autodetect=False) -> ProtoDeepSchema:
+def guess_schema(data: bytes, definitions: dict={}, bruteforce_index=20, no_autodetect=False, named_keychains=False) -> ProtoDeepSchema:
     if not no_autodetect:
         if data.strip().startswith(b"HTTP") and b"\r\n\r\n" in data:
             print("[!] Full request detected, extracting the body...")
@@ -168,12 +168,12 @@ def guess_schema(data: bytes, definitions: dict={}, bruteforce_index=20, no_auto
     parsed = schema[0]
     new_schema = schema[1]
 
-    new_schema, custom_types_defined = clean_schema(new_schema, parsed, definitions=definitions)
+    new_schema, custom_types_defined = clean_schema(new_schema, parsed, definitions=definitions, named_keychains=named_keychains)
     if custom_types_defined:
         schema = decode_message(data[data_index:], new_schema)
         parsed = schema[0]
         new_schema = schema[1]
-        new_schema, _ = clean_schema(new_schema, parsed, definitions=definitions)
+        new_schema, _ = clean_schema(new_schema, parsed, definitions=definitions, named_keychains=named_keychains)
 
     protodeep_schema = ProtoDeepSchema(schema=new_schema, values=parsed)
     return protodeep_schema

--- a/protodeep/modules/analyze.py
+++ b/protodeep/modules/analyze.py
@@ -74,8 +74,9 @@ def main(data: bytes=b"",
                     no_autodetect=no_autodetect,
                     named_keychains=named_keychains
                 )
-            except:
-                exit("[-] Can't decode the data. Please verify your type and bruteforce_index. Otherwise, RIP. 🥹")
+            except Exception as err:
+                print("Error :", err)
+                exit("\n[-] Can't decode the data. Please verify your type and bruteforce_index. Otherwise, RIP. 🥹")
         case "protodeep":
             import pickle
             from protodeep.lib import ProtoDeepSchema, clean_schema

--- a/protodeep/modules/analyze.py
+++ b/protodeep/modules/analyze.py
@@ -12,6 +12,7 @@ def main(data: bytes=b"",
         no_print: bool=False,
         data_type: str="",
         no_autodetect: bool=False,
+        named_keychains: bool=False,
         bruteforce_index: int=10,
         match_any: str="",
         match_keychain: str="",
@@ -70,7 +71,8 @@ def main(data: bytes=b"",
                     data=data,
                     definitions=definitions,
                     bruteforce_index=bruteforce_index,
-                    no_autodetect=no_autodetect
+                    no_autodetect=no_autodetect,
+                    named_keychains=named_keychains
                 )
             except:
                 exit("[-] Can't decode the data. Please verify your type and bruteforce_index. Otherwise, RIP. 🥹")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protodeep"
-version = "1.0.3"
+version = "1.1.0"
 authors = [
     {name = "mxrch", email = "mxrch.dev@pm.me"},
 ]


### PR DESCRIPTION
It permits to show and extract only values where their keychains are named.
Like :
`Applications[],i18,2,3,Downloads,real_count` -> extracted
`Applications[],i18,2,3,Downloads,4,1,1` -> not extracted

The most practical use is to generate much smaller protofiles, and for them to have a better chance of being compatible with all parsed data.